### PR TITLE
correction of title link when collapsed

### DIFF
--- a/disquaire_project/store/templates/store/base.html
+++ b/disquaire_project/store/templates/store/base.html
@@ -37,7 +37,7 @@
                     <span class="icon-bar"></span>
                 </button>
                 <!-- navbar-brand is hidden on larger screens, but visible when the menu is collapsed -->
-                <a class="navbar-brand" href="index.html">Le bateau pirate</a>
+                <a class="navbar-brand" href="/">Le bateau pirate</a>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">


### PR DESCRIPTION
When the nav is on small screen the href was "index.html"
it was a wrong adress

(my first pull request \o/)