### PR TITLE
Fixing store urlpatterns

### DIFF
--- a/disquaire_project/disquaire_project/urls.py
+++ b/disquaire_project/disquaire_project/urls.py
@@ -21,7 +21,7 @@ from store import views
 
 urlpatterns = [
     url(r'^$', views.index, name="index"),
-    url(r'^store/', include('store.urls', namespace='store')),
+    url(r'^store/', include(('store.urls', 'store'), namespace='store')),
     url(r'^admin/', admin.site.urls)
 ]
 


### PR DESCRIPTION
Line 24 was raising the error django.core.exceptions.ImproperlyConfigured because of namespace argument misplacing in Django 3